### PR TITLE
Set mandatory cookie for age-restricted boards

### DIFF
--- a/ptt/core.py
+++ b/ptt/core.py
@@ -28,6 +28,7 @@ class PTTSpider():
 
     headers = {
         'user-agent': settings.USER_AGENT,
+        'cookie': 'over18=1',
     }
 
     def __init__(self, board, loop):


### PR DESCRIPTION
The code wasn't working for certain boards (e.g., Gossiping) due to missing cookie, fix it either thru setting cookie in headers or send to `aiohttp.ClientSession`.